### PR TITLE
fix: Improve linting checks

### DIFF
--- a/mccole/lint.py
+++ b/mccole/lint.py
@@ -28,7 +28,7 @@ def lint(opt):
         lint_link_definitions,
         lint_markdown_links,
     ]
-    if all(f(opt, files) for f in linters):
+    if all(list(f(opt, files) for f in linters)):
         print("All self-checks passed.")
 
 


### PR DESCRIPTION
Current linter has 2 bugs that I have spotted based on these observations:

1) The linter fails to catch a glossary reference to the 'database migration' term in `11_migrate/index.md`.

2) There is a content mismatch between a section of js code in `08_js/index.md` and the corresponding content of the related `higher_order_func.js` (I updated index.md but not the related js).

However, the linter does not detect these issues:
```
$ make lint
All checks passed!
Missing bibliography keys in CONTRIBUTING.md: key
```

This patch fixes it so that missing terms in glossary and mismatch content in external files are detected:
```
$ make lint 
All checks passed!
Missing bibliography keys in CONTRIBUTING.md: key
Content mismatch: 08_js/index.md => higher_order_func.js
Missing glossary entries referenced in CONTRIBUTING.md: key
Missing glossary entries referenced in 11_migrate/index.md: db-migration
Some checks failed. See above for details.
```

Note 1: since `CONTRIBUTING.md` is meant to explain how to create such references, it makes sense that it could include example text that doesn't correspond to actual glossary or bibliography entries. We can exempt that file from linter, though.
Note 2: we may need to add some kind of header to the first 'All checks passed' to indicate that it is a message from ruff while the 'Some checks failed' message belongs to mccole/lint.
