### PR TITLE
feat: check that files are duplicated when they're supposed to be

### DIFF
--- a/mccole/util.py
+++ b/mccole/util.py
@@ -4,7 +4,8 @@ from pathlib import Path
 
 
 SUFFIXES_BIN = {".ico", ".jpg", ".png"}
-SUFFIXES_TXT = {".css", ".csv", ".html", ".js", ".json", ".md", ".py", ".sh", ".svg", ".txt"}
+SUFFIXES_SRC = {".css", ".html", ".js", ".md", ".py", ".sh", ".txt"}
+SUFFIXES_TXT = SUFFIXES_SRC | {".csv", ".json", ".svg"}
 SUFFIXES = SUFFIXES_BIN | SUFFIXES_TXT
 
 


### PR DESCRIPTION
-   split `SUFFIXES_TXT` into suffixes for source code files and suffixes for other text files
-   optionally load a configuration file in `lint.py`
    -   use an empty default configuration if none given
-   identify duplicated files via hashing
-   report mis-matches between expected duplicates (from configuration) and actual duplicates