### PR TITLE
fix: update mccole installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,11 +3,15 @@
 A template for building simple static websites.
 
 1.  `pip install mccole` to install.
-2.  `mccole install .` to copy the following tools into the current directory:
-    -   `bin/lint.py`: internal project check
-    -   `bin/render.py`: Markdown-to-HTML translator
+2.  `mccole install` to copy the following tools into the current directory:
     -   `static/page.css`: styling for regular pages
     -   `static/slides.css`: styling for slides
     -   `static/slides.js`: JavaScript to make slides interactive
     -   `templates/page.html`: Jinja template for pages
     -   `templates/slides.html`: Jinja template for slides
+
+
+After installation, the following commands will be available:
+
+-   `mccole lint`: internal project check
+-   `mccole render`: Markdown-to-HTML translator


### PR DESCRIPTION
The previous version stated that we should run `mccole install .`, but that led to an error:
```
$ mccole install .
usage: mccole [-h] [--version] {install,lint,render} ...
mccole: error: unrecognized arguments: .
```

Also, `lint`and `render` are not copied with the `mccole install` command (there were already available when installed with `pip`), thus my commit.