### PR TITLE
Set encoding explicitly to UTF-8 to deal with Windows OS

### DIFF
--- a/src/build.py
+++ b/src/build.py
@@ -45,7 +45,7 @@ def build(options):
 
 def _build_page(config, env, slug, src_path):
     """Handle a Markdown file."""
-    content = src_path.read_text()
+    content = src_path.read_text(encoding='utf-8')
     with_links = f"{content}\n\n{config['links']}"
     raw_html = markdown(with_links, extensions=MARKDOWN_EXTENSIONS)
 
@@ -216,7 +216,7 @@ def _is_interesting_file(config, excludes, filepath):
 def _load_configuration(options):
     """Load configuration and combine with options."""
     config_path = options.src / options.config
-    config = tomli.loads(config_path.read_text())
+    config = tomli.loads(config_path.read_text(encoding='utf-8'))
 
     links = util.load_links(options.src)
     glossary = _load_glossary(options.src)
@@ -241,7 +241,7 @@ def _load_configuration(options):
 
 def _load_glossary(src_path):
     """Load glossary keys and terms."""
-    md = (src_path / GLOSSARY_PATH).read_text()
+    md = (src_path / GLOSSARY_PATH).read_text(encoding='utf-8')
     html = markdown(md, extensions=MARKDOWN_EXTENSIONS)
     doc = BeautifulSoup(html, "html.parser")
     return {node["id"]: node.decode_contents() for node in doc.select("span[id]")}
@@ -249,7 +249,7 @@ def _load_glossary(src_path):
 
 def _load_order(src_path, home_page):
     """Determine section order from home page file."""
-    md = (src_path / home_page).read_text()
+    md = (src_path / home_page).read_text(encoding='utf-8')
     html = markdown(md, extensions=MARKDOWN_EXTENSIONS)
     doc = BeautifulSoup(html, "html.parser")
     lessons = _load_order_section(doc, "lessons", lambda i: str(i + 1))

--- a/src/build.py
+++ b/src/build.py
@@ -70,7 +70,7 @@ def _build_page(config, env, slug, src_path):
         func(config, dst_path, doc)
 
     try:
-        dst_path.write_text(str(doc))
+        dst_path.write_text(str(doc), encoding='utf-8')
     except Exception as exc:
         print(f"unable to write {dst_path} because {exc}")
         sys.exit(1)

--- a/src/check.py
+++ b/src/check.py
@@ -22,7 +22,7 @@ def check(options):
     dst_dir = Path(options.dst)
 
     paths = [dst_dir / "index.html"] + list(dst_dir.glob("*/index.html"))
-    pages = {fp: BeautifulSoup(fp.read_text(), "html.parser") for fp in paths}
+    pages = {fp: BeautifulSoup(fp.read_text(encoding='utf-8'), "html.parser") for fp in paths}
 
     for func in [_check_all_html, _check_glossary_redefinitions,]:
         func(pages)

--- a/src/util.py
+++ b/src/util.py
@@ -11,7 +11,7 @@ LINKS_PATH = EXTRAS_DIR / "links.md"
 def load_links(src_path):
     """Read links file if available."""
     links_path = src_path / LINKS_PATH
-    return links_path.read_text() if links_path.is_file() else ""
+    return links_path.read_text(encoding='utf-8') if links_path.is_file() else ""
 
 
 def warn(message):


### PR DESCRIPTION
Motivation:
---
This pull request contains minimal changes in reading and writing text to make build process to work properly on Windows. The change made involved setting encoding explicitly to be UTF-8 both on reading and writing. Apparently, without this explicit set of encoding, the encoding selected on Windows is cp1252 and there are errors on use of mccole build function (using it from https://github.com/gvwilson/sim.git).

Changes were tested in cited repo and apparently solves the exception without noticeable difference.

Trace information:
---
Command:

```bash
mccole build --src . --dst docs
```

Output:
```bash
unable to write docs\insight\index.html because 'charmap' codec can't encode character '\u21d0' in position 4039: character maps to <undefined>
Traceback (most recent call last):
  File ".\discrete-event-simulation-of-software-development\.venv\Lib\site-packages\src\build.py", line 72, in _build_page
    dst_path.write_text(str(doc))
    ~~~~~~~~~~~~~~~~~~~^^^^^^^^^^
  File "C:\Python313\Lib\pathlib\_local.py", line 555, in write_text
    return PathBase.write_text(self, data, encoding, errors, newline)
           ~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Python313\Lib\pathlib\_abc.py", line 652, in write_text
    return f.write(data)
           ~~~~~~~^^^^^^
  File "C:\Python313\Lib\encodings\cp1252.py", line 19, in encode
    return codecs.charmap_encode(input,self.errors,encoding_table)[0]
           ~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
UnicodeEncodeError: 'charmap' codec can't encode character '\u21d0' in position 4039: character maps to <undefined>

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File ".\discrete-event-simulation-of-software-development\.venv\Scripts\mccole.exe\__main__.py", line 10, in <module>
    sys.exit(clui.main())
             ~~~~~~~~~^^
  File ".\discrete-event-simulation-of-software-development\.venv\Lib\site-packages\src\clui.py", line 32, in main
    commands[args.command][0](args)
    ~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^
  File ".\discrete-event-simulation-of-software-development\.venv\Lib\site-packages\src\build.py", line 38, in build
    _build_page(config, env, slug, config["order"][slug]["filepath"])
    ~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File ".\discrete-event-simulation-of-software-development\.venv\Lib\site-packages\src\build.py", line 75, in _build_page
    sys.exit(1)
    ^^^
NameError: name 'sys' is not defined. Did you forget to import 'sys'?
```

Support information:
---
1. Help content for [write_text function from Pathlib](https://docs.python.org/3/library/pathlib.html#pathlib.Path.write_text)

> In text mode, if encoding is not specified the encoding used is platform-dependent: [locale.getencoding()](https://docs.python.org/3/library/locale.html#locale.getencoding) is called to get the current locale encoding. [Options for open function from built-in library](https://docs.python.org/3/library/functions.html#open)

2. Help content for [locale.getencoding](https://docs.python.org/3/library/locale.html#locale.getencoding) presents the following info:
> Get the current [locale encoding](https://docs.python.org/3/glossary.html#term-locale-encoding):

> - On Android and VxWorks, return "utf-8".

> - On Unix, return the encoding of the current [LC_CTYPE]
> (https://docs.python.org/3/library/locale.html#locale.LC_CTYPE) locale. Return "utf-8" if nl_langinfo(CODESET) returns an empty string: for example, if the current LC_CTYPE locale is not supported.

> - On Windows, return the ANSI code page.

Related issues / discussions:
---
- ['charmap' codec can't encode character '\u02da' #151](https://github.com/microsoft/markitdown/issues/151)
- [Charmap’ codec can’t encode characters in position 0-3: character maps to <undefined>](https://discuss.python.org/t/charmap-codec-cant-encode-characters-in-position-0-3-character-maps-to-undefined/53450)](https://discuss.python.org/t/charmap-codec-cant-encode-characters-in-position-0-3-character-maps-to-undefined/53450/5)