### PR TITLE
Proposed fix to correct links to glossary items

### DIFF
--- a/src/build.py
+++ b/src/build.py
@@ -413,7 +413,7 @@ def _patch_terms_defined(config, dst_path, doc):
         return
 
     keys = {k[2:] for k in keys}
-    entries = [(key, config["glossary"].get(key, "UNDEFINED")) for key in keys]
+    entries = [(f"../glossary/#{key}", config["glossary"].get(key, "UNDEFINED")) for key in keys]
     entries.sort(key=lambda item: item[1])
     para.append("Terms defined: ")
     for i, (key, term) in enumerate(entries):


### PR DESCRIPTION
Hi, @gvwilson :

Long time ago I have noticed that links to glossary in https://gvwilson.github.io/sim/ are broken as it can be seen in the image below:

<img width="2601" height="1016" alt="image" src="https://github.com/user-attachments/assets/f7f73dff-5de6-4885-9160-969493d7aed6" />

Debugging mccole from inside sim repo (see this branch for my setup - https://github.com/disouzam/mccole/tree/debugging-config), directly from sim repo, I could reach the potential solution - hard-coded here - to fix broken links. See image below for links working in my local build:

<img width="2290" height="1017" alt="image" src="https://github.com/user-attachments/assets/781ff63e-731c-41fa-8fd6-7efaee9edb35" />

I can perfect the solution later if you wish as I find more time to understand mccole better.